### PR TITLE
Fix kit title wrapping and encode font URLs

### DIFF
--- a/404.html
+++ b/404.html
@@ -8,7 +8,7 @@
     <meta name="description" content="The page you're looking for could not be found." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>

--- a/about.html
+++ b/about.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Learn about World Cup Kits - your destination for authentic replica football jerseys and World Cup merchandise." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>

--- a/cart.html
+++ b/cart.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Review your World Cup kit selections and proceed to checkout." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>

--- a/css/style.css
+++ b/css/style.css
@@ -657,6 +657,7 @@ p {
 .kit-title {
   display: flex;
   align-items: center;
+  flex-wrap: wrap;
   gap: var(--space-3);
   font-size: 1.125rem;
   margin-bottom: var(--space-2);

--- a/index.html
+++ b/index.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Shop authentic World Cup football kits and jerseys from your favorite national teams. Road to 2026 starts here!" />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>

--- a/kit-detail.html
+++ b/kit-detail.html
@@ -8,7 +8,7 @@
     <meta name="description" content="View detailed information about this World Cup football kit including sizes, pricing, and specifications." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>

--- a/kits.html
+++ b/kits.html
@@ -8,7 +8,7 @@
     <meta name="description" content="Browse our complete collection of World Cup football kits and jerseys from all participating teams." />
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Roboto:wght@400;700&amp;display=swap" rel="stylesheet">
     <link rel="stylesheet" href="css/style.css">
   </head>
   <body>


### PR DESCRIPTION
## Summary
- allow long kit titles to wrap instead of overflowing
- properly encode Google Fonts URLs

## Testing
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_6852004279dc832598b19741dd0870ef